### PR TITLE
Add cluster matmul example and test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -53,6 +53,26 @@ with shard(A, dim=0), shard(B, dim=1):
     C = A @ B
 ```
 
+## Examples
+
+A full program that shards a matrix multiplication across GPUs lives in [`examples/cluster_matmul.xg`](examples/cluster_matmul.xg).
+You can compile and execute it from Python with:
+
+```python
+from pathlib import Path
+
+import torch
+import xg
+
+engine = xg.compile_file(Path("examples/cluster_matmul.xg"))
+a = torch.randn(2, 4, dtype=torch.float32)
+b = torch.randn(4, 2, dtype=torch.float32)
+
+result = xg.run_engine(engine, external_values={"A": a, "B": b})
+print(result.value)
+print(result.metadata)
+```
+
 ## How to run?
 1. Locally for testing
     - `xgc model.xg --target=H100 --out build/engine.xge`

--- a/examples/cluster_matmul.xg
+++ b/examples/cluster_matmul.xg
@@ -1,0 +1,12 @@
+TARGET_GPU = GB200
+NUM_GPU = 8
+
+def matmul_block(Tensor[float32, M, K] A, Tensor[float32, K, N] B) -> Tensor[float32, M, N] {
+    with shard(A, dim=0), shard(B, dim=1) {
+        return A @ B
+    }
+}
+
+def main() -> Tensor[float32, 2, 2] {
+    return matmul_block(A, B)
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_xg_language.py
+++ b/tests/test_xg_language.py
@@ -1,0 +1,240 @@
+import json
+from pathlib import Path
+import textwrap
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from xg.compiler import compile_source, compile_file
+from xg.errors import XGTypeError, XGSafetyError, XGRuntimeError
+from xg.runtime import ExecutionResult, run_engine
+
+
+def compile_and_run(source: str, *, target: str | None = None, num_gpu: int | None = None, external=None) -> ExecutionResult:
+    engine = compile_source(source, target=target, num_gpu=num_gpu)
+    return run_engine(engine, external_values=external or {})
+
+
+def test_add_function_executes_integer_addition():
+    source = textwrap.dedent(
+        """
+        TARGET_GPU = H100
+        NUM_GPU = 8
+
+        def add(int64 a, int64 b) -> int64 {
+            return a + b
+        }
+
+        def main() -> int64 {
+            return add(10, 20)
+        }
+        """
+    )
+
+    result = compile_and_run(source)
+    assert result.value == 30
+    assert result.metadata["target_gpu"] == "H100"
+    assert result.metadata["num_gpu"] == 8
+
+
+def test_type_mismatch_is_caught_at_compile_time():
+    source = textwrap.dedent(
+        """
+        def bad(int64 a, float32 b) -> int64 {
+            return a + b
+        }
+
+        def main() -> int64 {
+            return bad(1, 2.0)
+        }
+        """
+    )
+
+    with pytest.raises(XGTypeError):
+        compile_source(source)
+
+
+def test_matrix_multiplication_type_checks_shapes():
+    source = textwrap.dedent(
+        """
+        def multMat(Tensor[float32, M, K] a, Tensor[float32, K, N] b) -> Tensor[float32, M, N] {
+            return a @ b
+        }
+
+        def main() -> Tensor[float32, 2, 3] {
+            return multMat(A, B)
+        }
+        """
+    )
+
+    a = torch.randn(2, 4, dtype=torch.float32)
+    b = torch.randn(4, 3, dtype=torch.float32)
+
+    result = compile_and_run(source, external={"A": a, "B": b})
+    assert torch.allclose(result.value, a @ b)
+
+
+def test_matrix_multiplication_incompatible_shapes_fail_compile():
+    source = textwrap.dedent(
+        """
+        def multMat(Tensor[float32, M, K] a, Tensor[float32, J, N] b) -> Tensor[float32, M, N] {
+            return a @ b
+        }
+
+        def main() -> Tensor[float32, 2, 3] {
+            return multMat(A, B)
+        }
+        """
+    )
+
+    with pytest.raises(XGTypeError):
+        compile_source(source)
+
+
+def test_division_by_zero_literal_is_rejected():
+    source = textwrap.dedent(
+        """
+        def unsafe(float32 a) -> float32 {
+            return a / 0.0
+        }
+
+        def main() -> float32 {
+            return unsafe(1.0)
+        }
+        """
+    )
+
+    with pytest.raises(XGSafetyError):
+        compile_source(source)
+
+
+def test_safe_division_requires_explicit_handling():
+    source = textwrap.dedent(
+        """
+        def safe_div(float32 a, float32 b) -> Result[float32] {
+            if b == 0 {
+                return DivByZero
+            }
+            return Ok(a / b)
+        }
+
+        def main() -> Result[float32] {
+            return safe_div(4.0, 2.0)
+        }
+        """
+    )
+
+    result = compile_and_run(source)
+    assert result.value.ok is True
+    assert pytest.approx(result.value.value) == 2.0
+
+    engine = compile_source(source)
+    zero_result = run_engine(engine, external_values={})
+    assert zero_result.value.ok is True
+
+    # A follow-up run where denominator is zero should return an error Result
+    def zero_main_source(base: str) -> str:
+        return base.replace("return safe_div(4.0, 2.0)", "return safe_div(4.0, 0.0)")
+
+    engine_zero = compile_source(zero_main_source(source))
+    zero_exec = run_engine(engine_zero)
+    assert zero_exec.value.ok is False
+    assert zero_exec.value.error == "DivByZero"
+
+
+def test_runtime_shape_mismatch_raises():
+    source = textwrap.dedent(
+        """
+        def multMat(Tensor[float32, M, K] a, Tensor[float32, K, N] b) -> Tensor[float32, M, N] {
+            return a @ b
+        }
+
+        def main() -> Tensor[float32, 2, 3] {
+            return multMat(A, B)
+        }
+        """
+    )
+
+    a = torch.randn(2, 4, dtype=torch.float32)
+    b = torch.randn(5, 3, dtype=torch.float32)
+
+    engine = compile_source(source)
+    with pytest.raises(XGRuntimeError):
+        run_engine(engine, external_values={"A": a, "B": b})
+
+
+def test_shard_block_records_plan():
+    source = textwrap.dedent(
+        """
+        TARGET_GPU = GB200
+        NUM_GPU = 16
+
+        def compute(Tensor[float32, M, K] A, Tensor[float32, K, N] B) -> Tensor[float32, M, N] {
+            with shard(A, dim=0), shard(B, dim=1) {
+                return A @ B
+            }
+        }
+
+        def main() -> Tensor[float32, 2, 3] {
+            return compute(A, B)
+        }
+        """
+    )
+
+    a = torch.randn(2, 4, dtype=torch.float32)
+    b = torch.randn(4, 3, dtype=torch.float32)
+
+    result = compile_and_run(source, external={"A": a, "B": b})
+    assert torch.allclose(result.value, a @ b)
+    assert ("A", 0) in result.metadata["sharding_plan"]
+    assert ("B", 1) in result.metadata["sharding_plan"]
+    assert result.metadata["target_gpu"] == "GB200"
+    assert result.metadata["num_gpu"] == 16
+
+
+def test_cli_round_trip(tmp_path: Path):
+    source_path = tmp_path / "model.xg"
+    engine_path = tmp_path / "engine.xge"
+    source = textwrap.dedent(
+        """
+        def add(int64 a, int64 b) -> int64 {
+            return a + b
+        }
+
+        def main() -> int64 {
+            return add(2, 3)
+        }
+        """
+    )
+    source_path.write_text(source)
+
+    engine = compile_file(source_path, target="H100", num_gpu=1)
+    assert engine_path.exists() is False
+
+    engine.save(engine_path)
+    assert engine_path.exists()
+
+    loaded = engine.__class__.load(engine_path)
+    result = run_engine(loaded)
+    assert result.value == 5
+
+    payload = json.loads(engine_path.read_text())
+    assert payload["target_gpu"] == "H100"
+    assert payload["num_gpu"] == 1
+
+
+def test_cluster_matmul_example_executes():
+    example_path = Path(__file__).resolve().parent.parent / "examples" / "cluster_matmul.xg"
+    engine = compile_file(example_path)
+
+    a = torch.randn(2, 4, dtype=torch.float32)
+    b = torch.randn(4, 2, dtype=torch.float32)
+
+    result = run_engine(engine, external_values={"A": a, "B": b})
+
+    assert torch.allclose(result.value, a @ b)
+    assert result.metadata["target_gpu"] == "GB200"
+    assert result.metadata["num_gpu"] == 8
+    assert ("A", 0) in result.metadata["sharding_plan"]
+    assert ("B", 1) in result.metadata["sharding_plan"]

--- a/xg/__init__.py
+++ b/xg/__init__.py
@@ -1,0 +1,10 @@
+from .compiler import compile_file, compile_source
+from .runtime import ExecutionResult, ResultValue, run_engine
+
+__all__ = [
+    "compile_source",
+    "compile_file",
+    "run_engine",
+    "ExecutionResult",
+    "ResultValue",
+]

--- a/xg/ast.py
+++ b/xg/ast.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+
+from .types import Type, type_from_dict, type_to_dict
+
+
+class Node:
+    def to_ir(self) -> Dict[str, Any]:  # pragma: no cover - abstract
+        raise NotImplementedError
+
+    @classmethod
+    def from_ir(cls, payload: Dict[str, Any]) -> "Node":  # pragma: no cover - abstract
+        raise NotImplementedError
+
+
+class Statement(Node):
+    pass
+
+
+class Expression(Node):
+    pass
+
+
+@dataclass
+class Program(Node):
+    statements: List[Statement]
+
+    def to_ir(self) -> Dict[str, Any]:
+        return {"node": "Program", "statements": [stmt.to_ir() for stmt in self.statements]}
+
+    @classmethod
+    def from_ir(cls, payload: Dict[str, Any]) -> "Program":
+        return cls(statements=[statement_from_ir(item) for item in payload["statements"]])
+
+
+@dataclass
+class Parameter:
+    typ: Type
+    name: str
+
+    def to_ir(self) -> Dict[str, Any]:
+        return {"type": type_to_dict(self.typ), "name": self.name}
+
+    @classmethod
+    def from_ir(cls, payload: Dict[str, Any]) -> "Parameter":
+        return cls(typ=type_from_dict(payload["type"]), name=payload["name"])
+
+
+@dataclass
+class Assignment(Statement):
+    target: str
+    expression: Expression
+
+    def to_ir(self) -> Dict[str, Any]:
+        return {"node": "Assignment", "target": self.target, "expression": self.expression.to_ir()}
+
+    @classmethod
+    def from_ir(cls, payload: Dict[str, Any]) -> "Assignment":
+        return cls(target=payload["target"], expression=expression_from_ir(payload["expression"]))
+
+
+@dataclass
+class Return(Statement):
+    expression: Optional[Expression]
+
+    def to_ir(self) -> Dict[str, Any]:
+        return {
+            "node": "Return",
+            "expression": None if self.expression is None else self.expression.to_ir(),
+        }
+
+    @classmethod
+    def from_ir(cls, payload: Dict[str, Any]) -> "Return":
+        expr = payload["expression"]
+        return cls(expression=None if expr is None else expression_from_ir(expr))
+
+
+@dataclass
+class If(Statement):
+    condition: Expression
+    then_body: List[Statement]
+    else_body: Optional[List[Statement]] = None
+
+    def to_ir(self) -> Dict[str, Any]:
+        return {
+            "node": "If",
+            "condition": self.condition.to_ir(),
+            "then": [stmt.to_ir() for stmt in self.then_body],
+            "else": None if self.else_body is None else [stmt.to_ir() for stmt in self.else_body],
+        }
+
+    @classmethod
+    def from_ir(cls, payload: Dict[str, Any]) -> "If":
+        return cls(
+            condition=expression_from_ir(payload["condition"]),
+            then_body=[statement_from_ir(item) for item in payload["then"]],
+            else_body=None
+            if payload["else"] is None
+            else [statement_from_ir(item) for item in payload["else"]],
+        )
+
+
+@dataclass
+class WithContext:
+    expression: Expression
+
+    def to_ir(self) -> Dict[str, Any]:
+        return {"expression": self.expression.to_ir()}
+
+    @classmethod
+    def from_ir(cls, payload: Dict[str, Any]) -> "WithContext":
+        return cls(expression=expression_from_ir(payload["expression"]))
+
+
+@dataclass
+class With(Statement):
+    contexts: List[WithContext]
+    body: List[Statement]
+
+    def to_ir(self) -> Dict[str, Any]:
+        return {
+            "node": "With",
+            "contexts": [ctx.to_ir() for ctx in self.contexts],
+            "body": [stmt.to_ir() for stmt in self.body],
+        }
+
+    @classmethod
+    def from_ir(cls, payload: Dict[str, Any]) -> "With":
+        return cls(
+            contexts=[WithContext.from_ir(item) for item in payload["contexts"]],
+            body=[statement_from_ir(item) for item in payload["body"]],
+        )
+
+
+@dataclass
+class ExpressionStatement(Statement):
+    expression: Expression
+
+    def to_ir(self) -> Dict[str, Any]:
+        return {"node": "ExpressionStatement", "expression": self.expression.to_ir()}
+
+    @classmethod
+    def from_ir(cls, payload: Dict[str, Any]) -> "ExpressionStatement":
+        return cls(expression=expression_from_ir(payload["expression"]))
+
+
+@dataclass
+class FunctionDef(Statement):
+    name: str
+    params: List[Parameter]
+    return_type: Optional[Type]
+    body: List[Statement]
+
+    def to_ir(self) -> Dict[str, Any]:
+        return {
+            "node": "FunctionDef",
+            "name": self.name,
+            "params": [param.to_ir() for param in self.params],
+            "return_type": None if self.return_type is None else type_to_dict(self.return_type),
+            "body": [stmt.to_ir() for stmt in self.body],
+        }
+
+    @classmethod
+    def from_ir(cls, payload: Dict[str, Any]) -> "FunctionDef":
+        return cls(
+            name=payload["name"],
+            params=[Parameter.from_ir(item) for item in payload["params"]],
+            return_type=None if payload["return_type"] is None else type_from_dict(payload["return_type"]),
+            body=[statement_from_ir(item) for item in payload["body"]],
+        )
+
+
+@dataclass
+class Number(Expression):
+    value: Union[int, float]
+
+    def to_ir(self) -> Dict[str, Any]:
+        return {"node": "Number", "value": self.value}
+
+    @classmethod
+    def from_ir(cls, payload: Dict[str, Any]) -> "Number":
+        return cls(value=payload["value"])
+
+
+@dataclass
+class Identifier(Expression):
+    name: str
+
+    def to_ir(self) -> Dict[str, Any]:
+        return {"node": "Identifier", "name": self.name}
+
+    @classmethod
+    def from_ir(cls, payload: Dict[str, Any]) -> "Identifier":
+        return cls(name=payload["name"])
+
+
+@dataclass
+class BinaryOp(Expression):
+    left: Expression
+    op: str
+    right: Expression
+
+    def to_ir(self) -> Dict[str, Any]:
+        return {"node": "BinaryOp", "op": self.op, "left": self.left.to_ir(), "right": self.right.to_ir()}
+
+    @classmethod
+    def from_ir(cls, payload: Dict[str, Any]) -> "BinaryOp":
+        return cls(
+            left=expression_from_ir(payload["left"]),
+            op=payload["op"],
+            right=expression_from_ir(payload["right"]),
+        )
+
+
+@dataclass
+class Call(Expression):
+    func: Expression
+    args: List[Expression] = field(default_factory=list)
+    kwargs: List[Tuple[str, Expression]] = field(default_factory=list)
+
+    def to_ir(self) -> Dict[str, Any]:
+        return {
+            "node": "Call",
+            "func": self.func.to_ir(),
+            "args": [arg.to_ir() for arg in self.args],
+            "kwargs": [{"name": name, "value": value.to_ir()} for name, value in self.kwargs],
+        }
+
+    @classmethod
+    def from_ir(cls, payload: Dict[str, Any]) -> "Call":
+        return cls(
+            func=expression_from_ir(payload["func"]),
+            args=[expression_from_ir(item) for item in payload["args"]],
+            kwargs=[(item["name"], expression_from_ir(item["value"])) for item in payload["kwargs"]],
+        )
+
+
+ExpressionDispatch = {
+    "Number": Number,
+    "Identifier": Identifier,
+    "BinaryOp": BinaryOp,
+    "Call": Call,
+}
+
+
+StatementDispatch = {
+    "Assignment": Assignment,
+    "Return": Return,
+    "If": If,
+    "With": With,
+    "ExpressionStatement": ExpressionStatement,
+    "FunctionDef": FunctionDef,
+}
+
+
+def expression_from_ir(payload: Dict[str, Any]) -> Expression:
+    node_type = payload["node"]
+    if node_type not in ExpressionDispatch:
+        raise ValueError(f"Unknown expression node: {node_type}")
+    cls = ExpressionDispatch[node_type]
+    return cls.from_ir(payload)
+
+
+def statement_from_ir(payload: Dict[str, Any]) -> Statement:
+    node_type = payload["node"]
+    if node_type not in StatementDispatch:
+        raise ValueError(f"Unknown statement node: {node_type}")
+    cls = StatementDispatch[node_type]
+    return cls.from_ir(payload)

--- a/xg/compiler.py
+++ b/xg/compiler.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from .engine import Engine
+from .parser import parse_source
+from .typechecker import HardwareSettings, TypeChecker
+
+
+def compile_source(source: str, *, target: Optional[str] = None, num_gpu: Optional[int] = None) -> Engine:
+    program = parse_source(source)
+    checker = TypeChecker(program)
+    hardware = checker.run()
+    effective_target = target if target is not None else hardware.target_gpu
+    effective_num_gpu = num_gpu if num_gpu is not None else hardware.num_gpu
+    if effective_num_gpu is None:
+        effective_num_gpu = 1
+    final_hardware = HardwareSettings(target_gpu=effective_target, num_gpu=effective_num_gpu)
+    return Engine(program=program, hardware=final_hardware)
+
+
+def compile_file(path: Path, *, target: Optional[str] = None, num_gpu: Optional[int] = None) -> Engine:
+    source = path.read_text()
+    return compile_source(source, target=target, num_gpu=num_gpu)

--- a/xg/engine.py
+++ b/xg/engine.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict
+
+from . import ast
+from .typechecker import HardwareSettings, TypeChecker
+
+
+@dataclass
+class Engine:
+    program: ast.Program
+    hardware: HardwareSettings
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "target_gpu": self.hardware.target_gpu,
+            "num_gpu": self.hardware.num_gpu,
+            "program": self.program.to_ir(),
+        }
+
+    def save(self, path: Path) -> None:
+        payload = self.to_dict()
+        path.write_text(json.dumps(payload, indent=2))
+
+    @classmethod
+    def load(cls, path: Path) -> "Engine":
+        payload = json.loads(path.read_text())
+        program = ast.Program.from_ir(payload["program"])
+        hardware = HardwareSettings(target_gpu=payload.get("target_gpu"), num_gpu=payload.get("num_gpu"))
+        return cls(program=program, hardware=hardware)
+
+    def function_map(self) -> Dict[str, ast.FunctionDef]:
+        functions: Dict[str, ast.FunctionDef] = {}
+        for stmt in self.program.statements:
+            if isinstance(stmt, ast.FunctionDef):
+                functions[stmt.name] = stmt
+        return functions
+
+    def ensure_checked(self) -> None:
+        checker = TypeChecker(self.program)
+        checker.run()

--- a/xg/errors.py
+++ b/xg/errors.py
@@ -1,0 +1,18 @@
+class XGError(Exception):
+    """Base class for all XG language errors."""
+
+
+class XGParseError(XGError):
+    """Raised when the source program cannot be parsed."""
+
+
+class XGTypeError(XGError):
+    """Raised when type checking fails."""
+
+
+class XGSafetyError(XGError):
+    """Raised when safety rules are violated at compile time."""
+
+
+class XGRuntimeError(XGError):
+    """Raised when runtime validation fails."""

--- a/xg/interpreter.py
+++ b/xg/interpreter.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import torch
+
+from . import ast
+from .engine import Engine
+from .errors import XGRuntimeError
+from .types import ResultType, TensorType, Type, VOID
+
+
+KNOWN_ERRORS = {"DivByZero"}
+
+
+@dataclass
+class ResultValue:
+    ok: bool
+    value: Any = None
+    error: Optional[str] = None
+
+    @classmethod
+    def ok(cls, value: Any) -> "ResultValue":
+        return cls(ok=True, value=value)
+
+    @classmethod
+    def error(cls, name: str) -> "ResultValue":
+        return cls(ok=False, error=name)
+
+
+@dataclass
+class ExecutionResult:
+    value: Any
+    metadata: Dict[str, Any]
+
+
+@dataclass
+class RuntimeContext:
+    engine: Engine
+    external: Dict[str, Any]
+    metadata: Dict[str, Any]
+
+
+@dataclass
+class CallFrame:
+    function: ast.FunctionDef
+    return_type: Type
+    env: Dict[str, Any] = field(default_factory=dict)
+    dim_bindings: Dict[str, int] = field(default_factory=dict)
+
+
+class ReturnSignal(Exception):
+    def __init__(self, value: Any):
+        self.value = value
+
+
+class Interpreter:
+    def __init__(self, engine: Engine):
+        self.engine = engine
+        self.functions = engine.function_map()
+        self.hardware = engine.hardware
+        if "main" not in self.functions:
+            raise XGRuntimeError("Program is missing a main function")
+
+    def run_main(self, external_values: Optional[Dict[str, Any]] = None) -> ExecutionResult:
+        metadata: Dict[str, Any] = {
+            "target_gpu": self.hardware.target_gpu,
+            "num_gpu": self.hardware.num_gpu,
+            "sharding_plan": [],
+        }
+        context = RuntimeContext(engine=self.engine, external=external_values or {}, metadata=metadata)
+        result = self._call_function("main", [], context)
+        return ExecutionResult(value=result, metadata=metadata)
+
+    def _call_function(self, name: str, args: Sequence[Any], context: RuntimeContext) -> Any:
+        if name not in self.functions:
+            raise XGRuntimeError(f"Unknown function {name}")
+        func = self.functions[name]
+        expected_params = func.params
+        if len(args) != len(expected_params):
+            raise XGRuntimeError(f"Function {name} expects {len(expected_params)} arguments")
+        frame = CallFrame(function=func, return_type=func.return_type or VOID)
+        for param, arg in zip(expected_params, args):
+            validated = self._validate_runtime_type(param.typ, arg, frame.dim_bindings)
+            frame.env[param.name] = validated
+        try:
+            for stmt in func.body:
+                self._execute_statement(stmt, frame, context)
+        except ReturnSignal as signal:
+            result = signal.value
+        else:
+            result = None
+        return self._validate_return_value(frame.return_type, result, frame.dim_bindings)
+
+    def _execute_statement(self, stmt: ast.Statement, frame: CallFrame, context: RuntimeContext) -> None:
+        if isinstance(stmt, ast.Assignment):
+            value = self._evaluate_expression(stmt.expression, frame, context)
+            frame.env[stmt.target] = value
+        elif isinstance(stmt, ast.Return):
+            if stmt.expression is None:
+                raise ReturnSignal(None)
+            value = self._evaluate_expression(stmt.expression, frame, context)
+            raise ReturnSignal(value)
+        elif isinstance(stmt, ast.If):
+            condition = self._evaluate_expression(stmt.condition, frame, context)
+            if not isinstance(condition, bool):
+                raise XGRuntimeError("if condition must be boolean")
+            body = stmt.then_body if condition else (stmt.else_body or [])
+            for body_stmt in body:
+                self._execute_statement(body_stmt, frame, context)
+        elif isinstance(stmt, ast.With):
+            self._execute_with(stmt, frame, context)
+        elif isinstance(stmt, ast.ExpressionStatement):
+            self._evaluate_expression(stmt.expression, frame, context)
+        else:  # pragma: no cover - defensive
+            raise XGRuntimeError(f"Unsupported statement {stmt}")
+
+    def _execute_with(self, stmt: ast.With, frame: CallFrame, context: RuntimeContext) -> None:
+        for ctx in stmt.contexts:
+            if not isinstance(ctx.expression, ast.Call):
+                raise XGRuntimeError("with context must be a call")
+            call = ctx.expression
+            if not isinstance(call.func, ast.Identifier) or call.func.name != "shard":
+                raise XGRuntimeError("Unsupported with context")
+            if len(call.args) != 1:
+                raise XGRuntimeError("shard expects exactly one tensor argument")
+            tensor_expr = call.args[0]
+            if not isinstance(tensor_expr, ast.Identifier):
+                raise XGRuntimeError("shard argument must be an identifier")
+            tensor_value = self._evaluate_expression(tensor_expr, frame, context)
+            if not isinstance(tensor_value, torch.Tensor):
+                raise XGRuntimeError("shard can only target tensors")
+            dim_kw = None
+            for name, value_expr in call.kwargs:
+                if name == "dim":
+                    dim_kw = value_expr
+            if dim_kw is None:
+                raise XGRuntimeError("shard requires a dim keyword argument")
+            dim_value = self._evaluate_expression(dim_kw, frame, context)
+            if not isinstance(dim_value, int):
+                raise XGRuntimeError("shard dim must be an integer")
+            if dim_value < 0 or dim_value >= tensor_value.dim():
+                raise XGRuntimeError("shard dim out of range")
+            entry = (tensor_expr.name, dim_value)
+            plan = context.metadata.setdefault("sharding_plan", [])
+            if entry not in plan:
+                plan.append(entry)
+        for body_stmt in stmt.body:
+            self._execute_statement(body_stmt, frame, context)
+
+    def _evaluate_expression(self, expr: ast.Expression, frame: CallFrame, context: RuntimeContext) -> Any:
+        if isinstance(expr, ast.Number):
+            return expr.value
+        if isinstance(expr, ast.Identifier):
+            if expr.name in frame.env:
+                return frame.env[expr.name]
+            if expr.name in context.external:
+                return context.external[expr.name]
+            if expr.name in KNOWN_ERRORS:
+                return ResultValue.error(expr.name)
+            raise XGRuntimeError(f"Unknown identifier {expr.name}")
+        if isinstance(expr, ast.BinaryOp):
+            left = self._evaluate_expression(expr.left, frame, context)
+            right = self._evaluate_expression(expr.right, frame, context)
+            if expr.op == "+":
+                return left + right
+            if expr.op == "-":
+                return left - right
+            if expr.op == "*":
+                return left * right
+            if expr.op == "/":
+                return left / right
+            if expr.op == "@":
+                if not isinstance(left, torch.Tensor) or not isinstance(right, torch.Tensor):
+                    raise XGRuntimeError("@ operator requires tensors")
+                return left @ right
+            if expr.op == "==":
+                return left == right
+            raise XGRuntimeError(f"Unsupported operator {expr.op}")
+        if isinstance(expr, ast.Call):
+            if isinstance(expr.func, ast.Identifier) and expr.func.name == "Ok":
+                if len(expr.args) != 1:
+                    raise XGRuntimeError("Ok expects one argument")
+                value = self._evaluate_expression(expr.args[0], frame, context)
+                return ResultValue.ok(value)
+            if isinstance(expr.func, ast.Identifier):
+                func_name = expr.func.name
+                args = [self._evaluate_expression(arg, frame, context) for arg in expr.args]
+                if func_name == "shard":
+                    raise XGRuntimeError("shard cannot be called as a function")
+                if expr.kwargs:
+                    raise XGRuntimeError("Keyword arguments are not supported in calls")
+                return self._call_function(func_name, args, context)
+            raise XGRuntimeError("Unsupported call expression")
+        raise XGRuntimeError(f"Unsupported expression {expr}")
+
+    def _validate_return_value(self, expected: Type, value: Any, dim_bindings: Dict[str, int]) -> Any:
+        if expected is VOID:
+            return None
+        if value is None:
+            raise XGRuntimeError("Missing return value")
+        return self._validate_runtime_type(expected, value, dim_bindings)
+
+    def _validate_runtime_type(self, expected: Type, value: Any, dim_bindings: Dict[str, int]) -> Any:
+        if expected is VOID:
+            return value
+        if isinstance(expected, ResultType):
+            if not isinstance(value, ResultValue):
+                raise XGRuntimeError("Expected a Result value")
+            if value.ok:
+                inner = self._validate_runtime_type(expected.inner, value.value, dim_bindings)
+                return ResultValue.ok(inner)
+            return ResultValue.error(value.error or "UnknownError")
+        if isinstance(expected, TensorType):
+            if not isinstance(value, torch.Tensor):
+                raise XGRuntimeError("Expected tensor value")
+            self._validate_tensor(expected, value, dim_bindings)
+            return value
+        if isinstance(expected, Type):
+            primitive_name = getattr(expected, "name", None)
+            if primitive_name in {"int64", "int32"}:
+                if not isinstance(value, int):
+                    raise XGRuntimeError("Expected integer value")
+                return int(value)
+            if primitive_name in {"float32", "float64"}:
+                if not isinstance(value, (int, float)):
+                    raise XGRuntimeError("Expected floating point value")
+                return float(value)
+            if primitive_name == "bool":
+                if not isinstance(value, bool):
+                    raise XGRuntimeError("Expected boolean value")
+                return value
+        return value
+
+    def _validate_tensor(self, expected: TensorType, value: torch.Tensor, dim_bindings: Dict[str, int]) -> None:
+        dtype_map = {
+            "float32": torch.float32,
+            "float64": torch.float64,
+            "int64": torch.int64,
+            "int32": torch.int32,
+        }
+        expected_dtype = dtype_map.get(expected.dtype.name)
+        if expected_dtype is None:
+            raise XGRuntimeError(f"Unsupported tensor dtype {expected.dtype.name}")
+        if value.dtype != expected_dtype:
+            raise XGRuntimeError("Tensor dtype mismatch")
+        if value.dim() != len(expected.dims):
+            raise XGRuntimeError("Tensor rank mismatch")
+        for size, dim in zip(value.shape, expected.dims):
+            if dim.is_literal:
+                if size != dim.value:
+                    raise XGRuntimeError("Tensor dimension mismatch")
+            else:
+                bound = dim_bindings.get(dim.value)
+                if bound is None:
+                    dim_bindings[dim.value] = size
+                elif bound != size:
+                    raise XGRuntimeError("Tensor dimension binding conflict")
+
+
+def run_engine(engine: Engine, external_values: Optional[Dict[str, Any]] = None) -> ExecutionResult:
+    interpreter = Interpreter(engine)
+    return interpreter.run_main(external_values)

--- a/xg/parser.py
+++ b/xg/parser.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+from . import ast
+from .errors import XGParseError
+from .types import Dimension, TensorType, ResultType, get_primitive, dimension_from_token
+
+
+@dataclass
+class Token:
+    kind: str
+    value: str
+
+
+KEYWORDS = {
+    "def": "DEF",
+    "return": "RETURN",
+    "if": "IF",
+    "else": "ELSE",
+    "with": "WITH",
+}
+
+
+class Lexer:
+    def __init__(self, source: str):
+        self.source = source
+        self.length = len(source)
+        self.index = 0
+
+    def tokenize(self) -> List[Token]:
+        tokens: List[Token] = []
+        while self.index < self.length:
+            ch = self.source[self.index]
+            if ch in " \t\r\n":
+                self.index += 1
+                continue
+            if ch == "#":
+                self._consume_comment()
+                continue
+            if ch.isalpha() or ch == "_":
+                tokens.append(self._consume_identifier())
+                continue
+            if ch.isdigit():
+                tokens.append(self._consume_number())
+                continue
+            if ch == ":":
+                tokens.append(Token("COLON", ch))
+                self.index += 1
+                continue
+            if ch == ",":
+                tokens.append(Token("COMMA", ch))
+                self.index += 1
+                continue
+            if ch == "[":
+                tokens.append(Token("LBRACKET", ch))
+                self.index += 1
+                continue
+            if ch == "]":
+                tokens.append(Token("RBRACKET", ch))
+                self.index += 1
+                continue
+            if ch == "(":
+                tokens.append(Token("LPAREN", ch))
+                self.index += 1
+                continue
+            if ch == ")":
+                tokens.append(Token("RPAREN", ch))
+                self.index += 1
+                continue
+            if ch == "{" or ch == "}":
+                tokens.append(Token("LBRACE" if ch == "{" else "RBRACE", ch))
+                self.index += 1
+                continue
+            if ch == "-" and self._peek_char() == ">":
+                tokens.append(Token("ARROW", "->"))
+                self.index += 2
+                continue
+            if ch == "=" and self._peek_char() == "=":
+                tokens.append(Token("EQ", "=="))
+                self.index += 2
+                continue
+            if ch in "+-*/@":
+                tokens.append(Token("OP", ch))
+                self.index += 1
+                continue
+            if ch == "=":
+                tokens.append(Token("ASSIGN", ch))
+                self.index += 1
+                continue
+            raise XGParseError(f"Unexpected character: {ch}")
+        tokens.append(Token("EOF", ""))
+        return tokens
+
+    def _peek_char(self) -> str:
+        if self.index + 1 < self.length:
+            return self.source[self.index + 1]
+        return ""
+
+    def _consume_comment(self) -> None:
+        while self.index < self.length and self.source[self.index] != "\n":
+            self.index += 1
+
+    def _consume_identifier(self) -> Token:
+        start = self.index
+        while self.index < self.length and (self.source[self.index].isalnum() or self.source[self.index] == "_"):
+            self.index += 1
+        value = self.source[start:self.index]
+        kind = KEYWORDS.get(value, "IDENT")
+        return Token(kind, value)
+
+    def _consume_number(self) -> Token:
+        start = self.index
+        has_dot = False
+        while self.index < self.length:
+            ch = self.source[self.index]
+            if ch == ".":
+                if has_dot:
+                    raise XGParseError("Malformed number literal")
+                has_dot = True
+                self.index += 1
+                continue
+            if not ch.isdigit():
+                break
+            self.index += 1
+        value = self.source[start:self.index]
+        return Token("NUMBER", value)
+
+
+class Parser:
+    def __init__(self, tokens: List[Token]):
+        self.tokens = tokens
+        self.index = 0
+
+    def parse(self) -> ast.Program:
+        statements: List[ast.Statement] = []
+        while not self._check("EOF"):
+            statements.append(self._parse_statement())
+        return ast.Program(statements=statements)
+
+    def _parse_statement(self) -> ast.Statement:
+        if self._match("DEF"):
+            return self._parse_function()
+        if self._match("RETURN"):
+            return self._parse_return()
+        if self._match("IF"):
+            return self._parse_if()
+        if self._match("WITH"):
+            return self._parse_with()
+        # Assignment or expression statement
+        expr = self._parse_expression()
+        if isinstance(expr, ast.Identifier) and self._match("ASSIGN"):
+            value = self._parse_expression()
+            return ast.Assignment(target=expr.name, expression=value)
+        if self._match("ASSIGN"):
+            raise XGParseError("Invalid assignment target")
+        return ast.ExpressionStatement(expression=expr)
+
+    def _parse_function(self) -> ast.FunctionDef:
+        name = self._consume("IDENT", "Expected function name").value
+        self._consume("LPAREN", "Expected '(' after function name")
+        params: List[ast.Parameter] = []
+        if not self._check("RPAREN"):
+            while True:
+                param_type = self._parse_type()
+                param_name = self._consume("IDENT", "Expected parameter name").value
+                params.append(ast.Parameter(typ=param_type, name=param_name))
+                if not self._match("COMMA"):
+                    break
+        self._consume("RPAREN", "Expected ')' after parameters")
+        return_type = None
+        if self._match("ARROW"):
+            return_type = self._parse_type()
+        self._consume("LBRACE", "Expected '{' to start function body")
+        body = self._parse_block()
+        return ast.FunctionDef(name=name, params=params, return_type=return_type, body=body)
+
+    def _parse_block(self) -> List[ast.Statement]:
+        statements: List[ast.Statement] = []
+        while not self._check("RBRACE"):
+            statements.append(self._parse_statement())
+        self._consume("RBRACE", "Expected '}' to close block")
+        return statements
+
+    def _parse_return(self) -> ast.Return:
+        if self._check("RBRACE"):
+            return ast.Return(expression=None)
+        expr = self._parse_expression()
+        return ast.Return(expression=expr)
+
+    def _parse_if(self) -> ast.If:
+        condition = self._parse_expression()
+        self._consume("LBRACE", "Expected '{' after if condition")
+        then_body = self._parse_block()
+        else_body: Optional[List[ast.Statement]] = None
+        if self._match("ELSE"):
+            self._consume("LBRACE", "Expected '{' after else")
+            else_body = self._parse_block()
+        return ast.If(condition=condition, then_body=then_body, else_body=else_body)
+
+    def _parse_with(self) -> ast.With:
+        contexts: List[ast.WithContext] = []
+        contexts.append(ast.WithContext(expression=self._parse_expression()))
+        while self._match("COMMA"):
+            contexts.append(ast.WithContext(expression=self._parse_expression()))
+        if self._match("COLON"):
+            pass
+        self._consume("LBRACE", "Expected '{' to start with-block body")
+        body = self._parse_block()
+        return ast.With(contexts=contexts, body=body)
+
+    def _parse_expression(self) -> ast.Expression:
+        return self._parse_equality()
+
+    def _parse_equality(self) -> ast.Expression:
+        expr = self._parse_additive()
+        while self._match("EQ"):
+            right = self._parse_additive()
+            expr = ast.BinaryOp(left=expr, op="==", right=right)
+        return expr
+
+    def _parse_additive(self) -> ast.Expression:
+        expr = self._parse_multiplicative()
+        while self._match("OP", "+") or self._match("OP", "-"):
+            op = self._previous().value
+            right = self._parse_multiplicative()
+            expr = ast.BinaryOp(left=expr, op=op, right=right)
+        return expr
+
+    def _parse_multiplicative(self) -> ast.Expression:
+        expr = self._parse_unary()
+        while True:
+            if self._match("OP", "*") or self._match("OP", "/") or self._match("OP", "@"):
+                op = self._previous().value
+                right = self._parse_unary()
+                expr = ast.BinaryOp(left=expr, op=op, right=right)
+                continue
+            break
+        return expr
+
+    def _parse_unary(self) -> ast.Expression:
+        if self._match("OP", "-"):
+            right = self._parse_unary()
+            zero = ast.Number(value=0)
+            return ast.BinaryOp(left=zero, op="-", right=right)
+        return self._parse_call()
+
+    def _parse_call(self) -> ast.Expression:
+        expr = self._parse_primary()
+        while self._match("LPAREN"):
+            expr = self._finish_call(expr)
+        return expr
+
+    def _finish_call(self, callee: ast.Expression) -> ast.Expression:
+        args: List[ast.Expression] = []
+        kwargs: List[tuple[str, ast.Expression]] = []
+        if not self._check("RPAREN"):
+            while True:
+                if self._check("IDENT") and self._check_next("ASSIGN"):
+                    name = self._consume("IDENT", "Expected keyword name").value
+                    self._consume("ASSIGN", "Expected '=' in keyword argument")
+                    value = self._parse_expression()
+                    kwargs.append((name, value))
+                else:
+                    args.append(self._parse_expression())
+                if not self._match("COMMA"):
+                    break
+        self._consume("RPAREN", "Expected ')' after arguments")
+        return ast.Call(func=callee, args=args, kwargs=kwargs)
+
+    def _parse_primary(self) -> ast.Expression:
+        if self._match("NUMBER"):
+            token = self._previous()
+            if "." in token.value:
+                return ast.Number(value=float(token.value))
+            return ast.Number(value=int(token.value))
+        if self._match("IDENT"):
+            return ast.Identifier(name=self._previous().value)
+        if self._match("LPAREN"):
+            expr = self._parse_expression()
+            self._consume("RPAREN", "Expected ')' after expression")
+            return expr
+        raise XGParseError("Expected expression")
+
+    def _parse_type(self):
+        name_token = self._consume("IDENT", "Expected type name")
+        name = name_token.value
+        if name == "Tensor":
+            self._consume("LBRACKET", "Expected '[' after Tensor")
+            dtype = self._parse_type()
+            self._consume("COMMA", "Expected ',' before Tensor dimensions")
+            dims: List[Dimension] = [self._parse_dimension()]
+            while self._match("COMMA"):
+                dims.append(self._parse_dimension())
+            self._consume("RBRACKET", "Expected ']' after Tensor type")
+            return TensorType(dtype=dtype, dims=tuple(dims))
+        if name == "Result":
+            self._consume("LBRACKET", "Expected '[' after Result")
+            inner = self._parse_type()
+            self._consume("RBRACKET", "Expected ']' after Result type")
+            return ResultType(inner=inner)
+        return get_primitive(name)
+
+    def _parse_dimension(self) -> Dimension:
+        if self._match("NUMBER"):
+            token = self._previous()
+            return dimension_from_token(int(token.value))
+        if self._match("IDENT"):
+            return dimension_from_token(self._previous().value)
+        raise XGParseError("Expected dimension literal")
+
+    def _match(self, kind: str, value: Optional[str] = None) -> bool:
+        if self._check(kind, value):
+            self.index += 1
+            return True
+        return False
+
+    def _consume(self, kind: str, message: str) -> Token:
+        if not self._check(kind):
+            raise XGParseError(message)
+        token = self.tokens[self.index]
+        self.index += 1
+        return token
+
+    def _check(self, kind: str, value: Optional[str] = None) -> bool:
+        if self.index >= len(self.tokens):
+            return False
+        token = self.tokens[self.index]
+        if token.kind != kind:
+            return False
+        if value is not None and token.value != value:
+            return False
+        return True
+
+    def _check_next(self, kind: str) -> bool:
+        if self.index + 1 >= len(self.tokens):
+            return False
+        return self.tokens[self.index + 1].kind == kind
+
+    def _previous(self) -> Token:
+        return self.tokens[self.index - 1]
+
+
+def parse_source(source: str) -> ast.Program:
+    lexer = Lexer(source)
+    tokens = lexer.tokenize()
+    parser = Parser(tokens)
+    return parser.parse()

--- a/xg/runtime.py
+++ b/xg/runtime.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from .engine import Engine
+from .interpreter import ExecutionResult, Interpreter, ResultValue
+
+
+def run_engine(engine: Engine, external_values: Optional[Dict[str, object]] = None) -> ExecutionResult:
+    interpreter = Interpreter(engine)
+    return interpreter.run_main(external_values)
+
+
+__all__ = ["run_engine", "ExecutionResult", "ResultValue"]

--- a/xg/typechecker.py
+++ b/xg/typechecker.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Set, Tuple
+
+from . import ast
+from .errors import XGSafetyError, XGTypeError
+from .types import (
+    Dimension,
+    ErrorType,
+    PrimitiveType,
+    ResultType,
+    TensorType,
+    Type,
+    UnknownType,
+    VOID,
+    get_primitive,
+    is_numeric,
+)
+
+
+BOOL = get_primitive("bool")
+INT64 = get_primitive("int64")
+FLOAT32 = get_primitive("float32")
+
+
+KNOWN_ERRORS = {"DivByZero"}
+
+
+@dataclass
+class HardwareSettings:
+    target_gpu: Optional[str] = None
+    num_gpu: Optional[int] = None
+
+
+@dataclass
+class FunctionContext:
+    name: str
+    env: Dict[str, Type]
+    return_type: Type
+    guard_nonzero: Set[str] = field(default_factory=set)
+    dim_bindings: Dict[str, Dimension] = field(default_factory=dict)
+
+
+class TypeChecker:
+    def __init__(self, program: ast.Program):
+        self.program = program
+        self.functions: Dict[str, ast.FunctionDef] = {}
+        self.hardware = HardwareSettings()
+
+    def run(self) -> HardwareSettings:
+        self._collect_top_level()
+        if "main" not in self.functions:
+            raise XGTypeError("Program must define a main function")
+        for func in self.functions.values():
+            self._check_function(func)
+        return self.hardware
+
+    def _collect_top_level(self) -> None:
+        for stmt in self.program.statements:
+            if isinstance(stmt, ast.FunctionDef):
+                if stmt.name in self.functions:
+                    raise XGTypeError(f"Function {stmt.name} defined multiple times")
+                self.functions[stmt.name] = stmt
+            elif isinstance(stmt, ast.Assignment):
+                self._process_hardware_assignment(stmt)
+            elif isinstance(stmt, ast.ExpressionStatement):
+                # Evaluate to ensure expression is well-formed even at top-level
+                self._infer_expression(stmt.expression, FunctionContext(name="<top>", env={}, return_type=VOID))
+
+    def _process_hardware_assignment(self, stmt: ast.Assignment) -> None:
+        if stmt.target == "TARGET_GPU":
+            value = self._extract_identifier_literal(stmt.expression)
+            self.hardware.target_gpu = value
+        elif stmt.target == "NUM_GPU":
+            if not isinstance(stmt.expression, ast.Number) or not isinstance(stmt.expression.value, int):
+                raise XGTypeError("NUM_GPU must be assigned an integer literal")
+            self.hardware.num_gpu = stmt.expression.value
+        else:
+            # For other assignments we simply ensure expression can be typed
+            self._infer_expression(stmt.expression, FunctionContext(name="<top>", env={}, return_type=VOID))
+
+    def _extract_identifier_literal(self, expr: ast.Expression) -> str:
+        if isinstance(expr, ast.Identifier):
+            return expr.name
+        raise XGTypeError("Hardware identifiers must be simple names")
+
+    def _check_function(self, func: ast.FunctionDef) -> None:
+        env = {param.name: param.typ for param in func.params}
+        return_type = func.return_type or VOID
+        context = FunctionContext(name=func.name, env=env, return_type=return_type)
+        for stmt in func.body:
+            self._check_statement(stmt, context)
+        if return_type is not VOID and func.name == "main":
+            # Ensure main returns something when typed
+            pass
+
+    def _check_statement(self, stmt: ast.Statement, context: FunctionContext) -> None:
+        if isinstance(stmt, ast.Assignment):
+            expr_type = self._infer_expression(stmt.expression, context)
+            existing = context.env.get(stmt.target)
+            if existing is not None:
+                self._ensure_assignable(existing, expr_type, context, stmt.expression)
+            context.env[stmt.target] = expr_type if existing is None else existing
+        elif isinstance(stmt, ast.Return):
+            if stmt.expression is None:
+                if context.return_type is not VOID:
+                    raise XGTypeError(f"Function {context.name} must return {context.return_type}")
+                return
+            expr_type = self._infer_expression(stmt.expression, context)
+            self._ensure_assignable(context.return_type, expr_type, context, stmt.expression)
+        elif isinstance(stmt, ast.If):
+            cond_type = self._infer_expression(stmt.condition, context)
+            if cond_type != BOOL:
+                raise XGTypeError("if condition must be boolean")
+            for body_stmt in stmt.then_body:
+                self._check_statement(body_stmt, context)
+            if stmt.else_body:
+                for body_stmt in stmt.else_body:
+                    self._check_statement(body_stmt, context)
+            self._maybe_register_guard(stmt, context)
+        elif isinstance(stmt, ast.With):
+            self._check_with(stmt, context)
+        elif isinstance(stmt, ast.ExpressionStatement):
+            self._infer_expression(stmt.expression, context)
+        else:  # pragma: no cover - defensive
+            raise XGTypeError(f"Unsupported statement: {stmt}")
+
+    def _maybe_register_guard(self, stmt: ast.If, context: FunctionContext) -> None:
+        cond = stmt.condition
+        guard_name: Optional[str] = None
+        if isinstance(cond, ast.BinaryOp) and cond.op == "==":
+            if isinstance(cond.left, ast.Identifier) and isinstance(cond.right, ast.Number) and cond.right.value == 0:
+                guard_name = cond.left.name
+            elif isinstance(cond.right, ast.Identifier) and isinstance(cond.left, ast.Number) and cond.left.value == 0:
+                guard_name = cond.right.name
+        if guard_name and self._branch_returns_error(stmt.then_body):
+            context.guard_nonzero.add(guard_name)
+
+    def _branch_returns_error(self, body: List[ast.Statement]) -> bool:
+        if len(body) != 1:
+            return False
+        stmt = body[0]
+        if not isinstance(stmt, ast.Return) or stmt.expression is None:
+            return False
+        expr = stmt.expression
+        return isinstance(expr, ast.Identifier) and expr.name in KNOWN_ERRORS
+
+    def _check_with(self, stmt: ast.With, context: FunctionContext) -> None:
+        for ctx in stmt.contexts:
+            if not isinstance(ctx.expression, ast.Call):
+                raise XGTypeError("with statements must use shard(...) contexts")
+            call = ctx.expression
+            if not isinstance(call.func, ast.Identifier) or call.func.name != "shard":
+                raise XGTypeError("Unsupported with context")
+            if len(call.args) != 1:
+                raise XGTypeError("shard expects a tensor variable")
+            tensor_expr = call.args[0]
+            tensor_type = self._infer_expression(tensor_expr, context)
+            if not isinstance(tensor_type, TensorType):
+                raise XGTypeError("shard can only be applied to tensors")
+            dim_kw = None
+            for name, value in call.kwargs:
+                if name == "dim":
+                    dim_kw = value
+            if dim_kw is None:
+                raise XGTypeError("shard requires a dim keyword argument")
+            if not isinstance(dim_kw, ast.Number) or not isinstance(dim_kw.value, int):
+                raise XGTypeError("shard dim must be an integer literal")
+            dim_index = dim_kw.value
+            if dim_index < 0 or dim_index >= len(tensor_type.dims):
+                raise XGTypeError("shard dim out of range for tensor")
+        for body_stmt in stmt.body:
+            self._check_statement(body_stmt, context)
+
+    def _infer_expression(self, expr: ast.Expression, context: FunctionContext) -> Type:
+        if isinstance(expr, ast.Number):
+            return FLOAT32 if isinstance(expr.value, float) else INT64
+        if isinstance(expr, ast.Identifier):
+            if expr.name in context.env:
+                return context.env[expr.name]
+            if expr.name in KNOWN_ERRORS:
+                return ErrorType(expr.name)
+            return UnknownType(expr.name)
+        if isinstance(expr, ast.BinaryOp):
+            return self._infer_binary(expr, context)
+        if isinstance(expr, ast.Call):
+            return self._infer_call(expr, context)
+        raise XGTypeError(f"Unsupported expression: {expr}")
+
+    def _infer_binary(self, expr: ast.BinaryOp, context: FunctionContext) -> Type:
+        if expr.op == "==":
+            left = self._infer_expression(expr.left, context)
+            right = self._infer_expression(expr.right, context)
+            self._ensure_comparable(left, right, expr)
+            return BOOL
+        if expr.op == "/":
+            right_type = self._infer_expression(expr.right, context)
+            self._enforce_division_safety(expr.right, context)
+            left_type = self._infer_expression(expr.left, context)
+            if left_type != right_type or left_type != FLOAT32:
+                raise XGTypeError("Division requires float32 operands with explicit safety handling")
+            return FLOAT32
+        if expr.op == "@":
+            left_type = self._infer_expression(expr.left, context)
+            right_type = self._infer_expression(expr.right, context)
+            if not isinstance(left_type, TensorType) or not isinstance(right_type, TensorType):
+                raise XGTypeError("@ operator requires tensors")
+            if left_type.dtype != right_type.dtype:
+                raise XGTypeError("Tensor dtypes must match for matmul")
+            if not left_type.dims or not right_type.dims:
+                raise XGTypeError("Tensors must have rank >= 2 for matmul")
+            inner_left = left_type.dims[-1]
+            inner_right = right_type.dims[0]
+            if inner_left.is_symbolic and inner_right.is_symbolic and inner_left.value != inner_right.value:
+                raise XGTypeError("Tensor inner dimensions must align for matmul")
+            self._unify_dimensions(inner_left, inner_right, context, expr)
+            result_dims = left_type.dims[:-1] + right_type.dims[1:]
+            return TensorType(dtype=left_type.dtype, dims=result_dims)
+        if expr.op in {"+", "-", "*"}:
+            left_type = self._infer_expression(expr.left, context)
+            right_type = self._infer_expression(expr.right, context)
+            if left_type != right_type or not is_numeric(left_type):
+                raise XGTypeError(f"Operator {expr.op} requires matching numeric types")
+            return left_type
+        raise XGTypeError(f"Unsupported operator {expr.op}")
+
+    def _infer_call(self, expr: ast.Call, context: FunctionContext) -> Type:
+        if isinstance(expr.func, ast.Identifier):
+            name = expr.func.name
+            if name == "Ok":
+                if len(expr.args) != 1 or expr.kwargs:
+                    raise XGTypeError("Ok expects a single argument")
+                inner = self._infer_expression(expr.args[0], context)
+                return ResultType(inner)
+            if name == "shard":
+                raise XGTypeError("shard context may only appear inside with blocks")
+            if name in self.functions:
+                return self._check_function_call(name, expr, context)
+        raise XGTypeError("Unknown function call")
+
+    def _check_function_call(self, name: str, call: ast.Call, context: FunctionContext) -> Type:
+        func_def = self.functions[name]
+        if len(call.args) != len(func_def.params):
+            raise XGTypeError(f"Function {name} expects {len(func_def.params)} arguments")
+        if call.kwargs:
+            raise XGTypeError("Keyword arguments are not supported for function calls")
+        for arg_expr, param in zip(call.args, func_def.params):
+            arg_type = self._infer_expression(arg_expr, context)
+            self._ensure_assignable(param.typ, arg_type, context, arg_expr)
+        return func_def.return_type or VOID
+
+    def _ensure_assignable(self, expected: Type, actual: Type, context: FunctionContext, node: ast.Expression) -> None:
+        if isinstance(actual, UnknownType):
+            context.env[actual.name] = expected
+            return
+        if expected == actual:
+            return
+        if isinstance(expected, PrimitiveType) and isinstance(actual, PrimitiveType) and expected == actual:
+            return
+        if isinstance(expected, TensorType) and isinstance(actual, TensorType):
+            self._ensure_tensor_compatible(expected, actual, context, node)
+            return
+        if isinstance(expected, ResultType):
+            if isinstance(actual, ResultType):
+                self._ensure_assignable(expected.inner, actual.inner, context, node)
+                return
+            if isinstance(actual, ErrorType):
+                return
+        if expected is VOID and actual is VOID:
+            return
+        raise XGTypeError(f"Cannot assign {actual} to {expected}")
+
+    def _ensure_tensor_compatible(
+        self, expected: TensorType, actual: TensorType, context: FunctionContext, node: ast.Expression
+    ) -> None:
+        if expected.dtype != actual.dtype:
+            raise XGTypeError("Tensor dtypes must match")
+        if len(expected.dims) != len(actual.dims):
+            raise XGTypeError("Tensor ranks must match")
+        for exp_dim, act_dim in zip(expected.dims, actual.dims):
+            self._unify_dimensions(exp_dim, act_dim, context, node)
+
+    def _unify_dimensions(self, expected: Dimension, actual: Dimension, context: FunctionContext, node: ast.Expression) -> None:
+        resolved_expected = self._resolve_dimension(expected, context)
+        resolved_actual = self._resolve_dimension(actual, context)
+        if resolved_expected.is_literal and resolved_actual.is_literal:
+            if resolved_expected.value != resolved_actual.value:
+                raise XGTypeError("Tensor dimensions are incompatible")
+            return
+        if resolved_expected.is_literal and resolved_actual.is_symbolic:
+            context.dim_bindings[resolved_actual.value] = resolved_expected
+            return
+        if resolved_expected.is_symbolic and resolved_actual.is_literal:
+            context.dim_bindings[resolved_expected.value] = resolved_actual
+            return
+        if resolved_expected.is_symbolic and resolved_actual.is_symbolic:
+            context.dim_bindings[resolved_actual.value] = resolved_expected
+            return
+        raise XGTypeError("Unsupported dimension combination")
+
+    def _resolve_dimension(self, dim: Dimension, context: FunctionContext) -> Dimension:
+        current = dim
+        visited: Set[str] = set()
+        while current.is_symbolic and current.value in context.dim_bindings:
+            if current.value in visited:
+                break
+            visited.add(current.value)
+            current = context.dim_bindings[current.value]
+        return current
+
+    def _ensure_comparable(self, left: Type, right: Type, expr: ast.BinaryOp) -> None:
+        if isinstance(left, PrimitiveType) and isinstance(right, PrimitiveType):
+            if left == right:
+                return
+            if is_numeric(left) and is_numeric(right):
+                return
+        if isinstance(left, TensorType) and isinstance(right, TensorType):
+            if left.dtype != right.dtype or len(left.dims) != len(right.dims):
+                raise XGTypeError("Tensor comparison requires matching shape")
+            return
+        if isinstance(left, UnknownType) or isinstance(right, UnknownType):
+            return
+        raise XGTypeError(f"Cannot compare types {left} and {right}")
+
+    def _enforce_division_safety(self, denominator: ast.Expression, context: FunctionContext) -> None:
+        if isinstance(denominator, ast.Number):
+            if denominator.value == 0:
+                raise XGSafetyError("Division by zero is not allowed")
+            return
+        if isinstance(denominator, ast.Identifier):
+            if denominator.name in context.guard_nonzero:
+                return
+            raise XGSafetyError(f"Division involving {denominator.name} requires explicit zero check")
+        raise XGSafetyError("Division requires explicit error handling")
+
+
+def type_check(program: ast.Program) -> HardwareSettings:
+    checker = TypeChecker(program)
+    return checker.run()

--- a/xg/types.py
+++ b/xg/types.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+
+DimensionValue = Union[int, str]
+
+
+@dataclass(frozen=True)
+class Dimension:
+    """Represents either a symbolic or literal tensor dimension."""
+
+    value: DimensionValue
+
+    @property
+    def is_symbolic(self) -> bool:
+        return isinstance(self.value, str)
+
+    @property
+    def is_literal(self) -> bool:
+        return isinstance(self.value, int)
+
+    def __str__(self) -> str:  # pragma: no cover - debug helper
+        return str(self.value)
+
+
+class Type:
+    """Base class for all types."""
+
+    def to_dict(self) -> Dict[str, Any]:  # pragma: no cover - overridden
+        raise NotImplementedError
+
+    def __str__(self) -> str:  # pragma: no cover - debug helper
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class PrimitiveType(Type):
+    name: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"kind": "primitive", "name": self.name}
+
+    def __str__(self) -> str:  # pragma: no cover - debug helper
+        return self.name
+
+
+@dataclass(frozen=True)
+class TensorType(Type):
+    dtype: PrimitiveType
+    dims: Tuple[Dimension, ...]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "kind": "tensor",
+            "dtype": self.dtype.to_dict(),
+            "dims": [dim.value for dim in self.dims],
+        }
+
+    def __str__(self) -> str:  # pragma: no cover
+        dims = ", ".join(str(d.value) for d in self.dims)
+        return f"Tensor[{self.dtype}, {dims}]"
+
+
+@dataclass(frozen=True)
+class ResultType(Type):
+    inner: Type
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"kind": "result", "inner": self.inner.to_dict()}
+
+    def __str__(self) -> str:  # pragma: no cover
+        return f"Result[{self.inner}]"
+
+
+@dataclass(frozen=True)
+class VoidType(Type):
+    def to_dict(self) -> Dict[str, Any]:
+        return {"kind": "void"}
+
+    def __str__(self) -> str:  # pragma: no cover
+        return "void"
+
+
+@dataclass(frozen=True)
+class ErrorType(Type):
+    name: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"kind": "error", "name": self.name}
+
+    def __str__(self) -> str:  # pragma: no cover
+        return f"Error[{self.name}]"
+
+
+@dataclass(frozen=True)
+class UnknownType(Type):
+    name: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"kind": "unknown", "name": self.name}
+
+    def __str__(self) -> str:  # pragma: no cover
+        return f"Unknown[{self.name}]"
+
+
+PrimitiveTable: Dict[str, PrimitiveType] = {}
+
+
+def get_primitive(name: str) -> PrimitiveType:
+    if name not in PrimitiveTable:
+        PrimitiveTable[name] = PrimitiveType(name)
+    return PrimitiveTable[name]
+
+
+VOID = VoidType()
+
+
+def dimension_from_token(token: Union[str, int]) -> Dimension:
+    if isinstance(token, int):
+        return Dimension(token)
+    if isinstance(token, str) and token.isdigit():
+        return Dimension(int(token))
+    return Dimension(str(token))
+
+
+def type_from_dict(payload: Dict[str, Any]) -> Type:
+    kind = payload["kind"]
+    if kind == "primitive":
+        return get_primitive(payload["name"])
+    if kind == "tensor":
+        dtype = type_from_dict(payload["dtype"])
+        if not isinstance(dtype, PrimitiveType):  # pragma: no cover - defensive
+            raise TypeError("Tensor dtype must be primitive")
+        dims = tuple(dimension_from_token(dim) for dim in payload["dims"])
+        return TensorType(dtype=dtype, dims=dims)
+    if kind == "result":
+        return ResultType(inner=type_from_dict(payload["inner"]))
+    if kind == "void":
+        return VOID
+    if kind == "error":
+        return ErrorType(payload["name"])
+    if kind == "unknown":
+        return UnknownType(payload["name"])
+    raise ValueError(f"Unknown type payload: {payload}")
+
+
+def type_to_dict(typ: Type) -> Dict[str, Any]:
+    return typ.to_dict()
+
+
+def is_numeric(typ: Type) -> bool:
+    return isinstance(typ, PrimitiveType) and typ.name in {"int64", "float32", "float64", "int32"}
+
+
+def is_integer(typ: Type) -> bool:
+    return isinstance(typ, PrimitiveType) and typ.name.startswith("int")
+
+
+def is_float(typ: Type) -> bool:
+    return isinstance(typ, PrimitiveType) and typ.name.startswith("float")


### PR DESCRIPTION
## Summary
- add a multi-GPU matrix multiplication program under `examples/cluster_matmul.xg`
- document how to compile and run the example from Python in the README
- extend the test suite to execute the example (skipping when PyTorch is unavailable)

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c9a8f457108329aaf9bbafec30ef13